### PR TITLE
Plaintext password should not be stored

### DIFF
--- a/src/me/stutiguias/webportal/webserver/request/type/LoginRequest.java
+++ b/src/me/stutiguias/webportal/webserver/request/type/LoginRequest.java
@@ -36,7 +36,7 @@ public class LoginRequest extends HttpResponse {
             LoggedPlayer _AuthPlayer = new LoggedPlayer();
             WebSitePlayer _AuctionPlayer = plugin.dataQueries.getPlayer(username);
             if(_AuctionPlayer == null) {
-                plugin.dataQueries.createPlayer(username,pass, 1, 1, 0);
+                plugin.dataQueries.createPlayer(username,"", 1, 1, 0);
                 _AuctionPlayer = plugin.dataQueries.getPlayer(username);
             }
             if(_AuctionPlayer.getWebban().equalsIgnoreCase("Y")){


### PR DESCRIPTION
When AuthSystem.System is set to Authme, if a player is logged in through website and his info is not stored in WA_Players, the plugin will insert a new row and use his plain text login password as password column, which is not necessary and causes secure problem.

Here is a quick fix, insert null string instead of plain text password.

workaround for http://dev.bukkit.org/bukkit-plugins/webportal/tickets/68-web-portal-stores-plaintext-passwords-in-db-when-auth/
